### PR TITLE
Simplify pass file format supported by oauth2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ More information may be found in the pass-oauth2(1) man page.
 
 ## Examples
 
-A pass file with refresh token, url and other metadata for the OAUTH2 exchange.
+A pass file with refresh token, url and other data parameters for the OAUTH2 exchange.
 
 ```
 $ pass email/gmail
-{refresh_token}
-url: https://accounts.google.com/oauth2/token
-grant_type: refresh_token
-client_id: xxxxxxxxxx
-client_secret: xxxxxxxxxx
+url: https://accounts.google.com/o/oauth2/token
+refresh_token: {refresh_token}"
+grant_type: refresh_token"
+client_id: {client_id}"
+client_secret: {client_secret}"
 ```
 
 Exchange for an access token

--- a/oauth2.bash
+++ b/oauth2.bash
@@ -51,7 +51,8 @@ cmd_oauth2() {
         if [[ "$line" == url:* ]]; then
             cconf+="$line"
         else
-            cconf+="$(awk -F ': ' '{ printf "-d " $1 "=" $2 }' <<< "$line")"
+            cconf+="$(awk -F ': ' \
+                '{if ($2 != "") printf "-d " $1 "=" $2 }' <<< "$line")"
         fi
         cconf+=$'\n'
     done < <($GPG -d "${GPG_OPTS[@]}" "$passfile")


### PR DESCRIPTION
Require the pass file to contain `key: value` lines

All keys except the `url: ...` will be included as data in the POST
request sent to the HTTP server

Example

    url: http://example/oauth2/token
    grant_type: refresh_token
    refresh_token: {refresh_token}
    client_id: xxxx
    client_secret: xxxx

fixes: https://github.com/frodeaa/pass-oauth2/issues/6